### PR TITLE
DAOS-4264 dfio: printout error messages in daos_fio_cleanup()

### DIFF
--- a/daos_fio.c
+++ b/daos_fio.c
@@ -186,6 +186,7 @@ static void
 daos_fio_cleanup(struct thread_data *td)
 {
 	struct daos_data *dd = td->io_ops_data;
+	int rc;
 
 	pthread_mutex_lock(&daos_mutex);
 	num_threads--;
@@ -197,10 +198,19 @@ daos_fio_cleanup(struct thread_data *td)
 		return;
 	}
 
-	dfs_umount(dd->dfs);
-	daos_cont_close(dd->coh, NULL);
-	daos_pool_disconnect(dd->poh, NULL);
-	daos_fini();
+	rc = dfs_umount(dd->dfs);
+	if (rc)
+		D_ERROR("failed to umount dfs: rc = %d\n", rc);
+	rc = daos_cont_close(dd->coh, NULL);
+	if (rc)
+		D_ERROR("failed to close container: "DF_RC"\n", DP_RC(rc));
+	rc = daos_pool_disconnect(dd->poh, NULL);
+	if (rc)
+		D_ERROR("failed to disconnect pool: "DF_RC"\n", DP_RC(rc));
+	rc = daos_fini();
+	if (rc)
+		D_ERROR("failed to finalize daos: "DF_RC"\n", DP_RC(rc));
+
 	free(dd->io_us);
 	free(dd);
 	daos_initialized = false;

--- a/daos_fio.c
+++ b/daos_fio.c
@@ -41,6 +41,18 @@ do {									\
 	return -1;							\
 } while (0)
 
+#define ERR_PRINT(rc, format, ...)					\
+do {									\
+	int _rc = (rc);							\
+									\
+	if (_rc < 0) {							\
+		fprintf(stderr, "ERROR (%s:%d): %d: "			\
+			format"\n", __FILE__, __LINE__,  _rc,		\
+			##__VA_ARGS__);					\
+		fflush(stderr);						\
+	}								\
+} while (0)
+
 #define DCHECK(rc, format, ...)						\
 do {									\
 	int _rc = (rc);							\
@@ -199,17 +211,13 @@ daos_fio_cleanup(struct thread_data *td)
 	}
 
 	rc = dfs_umount(dd->dfs);
-	if (rc)
-		D_ERROR("failed to umount dfs: rc = %d\n", rc);
+	ERR_PRINT(rc, "failed to umount dfs.");
 	rc = daos_cont_close(dd->coh, NULL);
-	if (rc)
-		D_ERROR("failed to close container: "DF_RC"\n", DP_RC(rc));
+	ERR_PRINT(rc, "failed to close container.");
 	rc = daos_pool_disconnect(dd->poh, NULL);
-	if (rc)
-		D_ERROR("failed to disconnect pool: "DF_RC"\n", DP_RC(rc));
+	ERR_PRINT(rc, "failed to disconnect pool.");
 	rc = daos_fini();
-	if (rc)
-		D_ERROR("failed to finalize daos: "DF_RC"\n", DP_RC(rc));
+	ERR_PRINT(rc, "failed to finalize daos.");
 
 	free(dd->io_us);
 	free(dd);

--- a/daos_fio_async.c
+++ b/daos_fio_async.c
@@ -32,6 +32,7 @@
 #include <daos_fs.h>
 #include <gurt/common.h>
 #include <gurt/hash.h>
+
 #define ERR(MSG)							\
 do {									\
 	fprintf(stderr, "ERROR (%s:%d): %s",				\

--- a/daos_fio_async.c
+++ b/daos_fio_async.c
@@ -32,13 +32,24 @@
 #include <daos_fs.h>
 #include <gurt/common.h>
 #include <gurt/hash.h>
-
 #define ERR(MSG)							\
 do {									\
 	fprintf(stderr, "ERROR (%s:%d): %s",				\
 		__FILE__, __LINE__, MSG);				\
 	fflush(stderr);							\
 	return -1;							\
+} while (0)
+
+#define ERR_PRINT(rc, format, ...)					\
+do {									\
+	int _rc = (rc);							\
+									\
+	if (_rc < 0) {							\
+		fprintf(stderr, "ERROR (%s:%d): %d: "			\
+			format"\n", __FILE__, __LINE__,  _rc,		\
+			##__VA_ARGS__);					\
+		fflush(stderr);						\
+	}								\
 } while (0)
 
 #define DCHECK(rc, format, ...)						\
@@ -195,6 +206,7 @@ static void
 daos_fio_cleanup(struct thread_data *td)
 {
 	struct daos_data *dd = td->io_ops_data;
+	int rc;
 
 	pthread_mutex_lock(&daos_mutex);
 	num_threads--;
@@ -206,10 +218,14 @@ daos_fio_cleanup(struct thread_data *td)
 		return;
 	}
 
-	dfs_umount(dd->dfs);
-	daos_cont_close(dd->coh, NULL);
-	daos_pool_disconnect(dd->poh, NULL);
-	daos_fini();
+	rc = dfs_umount(dd->dfs);
+	ERR_PRINT(rc, "failed to umount dfs.");
+	rc = daos_cont_close(dd->coh, NULL);
+	ERR_PRINT(rc, "failed to close container.");
+	rc = daos_pool_disconnect(dd->poh, NULL);
+	ERR_PRINT(rc, "failed to disconnect pool.");
+	rc = daos_fini();
+	ERR_PRINT(rc, "failed to finalize daos.");
 	free(dd->io_us);
 	free(dd);
 	daos_initialized = false;


### PR DESCRIPTION
While daos_fio_cleanup() doesn't return rc to upper stack, print out
errors in this function.

Signed-off-by: Hua Kuang <hua.kuang@intel.com>